### PR TITLE
Don't use generic default icon

### DIFF
--- a/helm/eventrouter-app/Chart.yaml
+++ b/helm/eventrouter-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v0.3
 description: "Heptio Event Router: A simple introspective kubernetes service that forwards events to a specified sink."
 home: https://github.com/heptiolabs/eventrouter
 name: eventrouter-app
-# icon: 
+# icon:
 maintainers:
 - name: Heptio/VMWare
   url: https://github.com/heptiolabs/eventrouter

--- a/helm/eventrouter-app/Chart.yaml
+++ b/helm/eventrouter-app/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: v0.3
 description: "Heptio Event Router: A simple introspective kubernetes service that forwards events to a specified sink."
 home: https://github.com/heptiolabs/eventrouter
 name: eventrouter-app
-# icon:
 maintainers:
 - name: Heptio/VMWare
   url: https://github.com/heptiolabs/eventrouter

--- a/helm/eventrouter-app/Chart.yaml
+++ b/helm/eventrouter-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v0.3
 description: "Heptio Event Router: A simple introspective kubernetes service that forwards events to a specified sink."
 home: https://github.com/heptiolabs/eventrouter
 name: eventrouter-app
-icon: https://s.giantswarm.io/app-icons/1/png/eventrouter-app-light.png
+# icon: 
 maintainers:
 - name: Heptio/VMWare
   url: https://github.com/heptiolabs/eventrouter


### PR DESCRIPTION
The icon used was a copy of a generic default icon which isn't app-specific. We should not use it.